### PR TITLE
feat: adds llm-friendly method description registration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,94 @@ the routes for this server are mounted at `/agents/api/v1/` see "Configuring you
 
 Once your server is configured, you need to do two things:
 - Register services, aka, types with exported methods that can be called by agents.
-- Describe those services' methods, which provides calling agents a description of what the methods do, and what parameters they accent.
+- Describe those services' methods, which provides calling agents a description of what the methods do, and what parameters they accept.
+
+### Method Registration: Two Approaches
+
+The Agent SDK provides two ways to describe your service methods, each suited for different use cases:
+
+#### Traditional Structured Registration (`DescribeServiceMethod`)
+
+Use this approach when you want strict type validation and structured parameter schemas. It's ideal for:
+- APIs consumed by traditional programmatic clients
+- When you need guaranteed type safety and validation
+- Building services with well-defined, stable interfaces
+
+```go
+// Register with structured parameter schema
+parameters := map[string]any{
+    "name": map[string]any{
+        "type":        "string",
+        "description": "The name to greet",
+        "required":    true,
+    },
+    "age": map[string]any{
+        "type":        "number",
+        "description": "Age in years",
+        "minimum":     0,
+    },
+}
+
+agentsdk.DescribeServiceMethod(server, "UserService", "CreateUser", 
+    "Creates a new user account", parameters)
+```
+
+**Pros:**
+- Strict parameter validation
+- Type-safe API contracts
+- Well-suited for traditional API clients
+- Structured, machine-readable schemas
+
+**Cons:**
+- More verbose to write and maintain
+- Less flexible for dynamic or complex parameter structures
+- Requires careful schema definition
+
+#### LLM-Friendly Registration (`DescribeServiceMethodLLM`)
+
+Use this approach when building APIs that will be consumed by Large Language Models or AI agents. It's ideal for:
+- Services designed for AI/LLM consumption
+- When you want to provide rich natural language context
+- APIs that need flexibility in parameter descriptions
+- Building agent-to-agent communication
+
+```go
+// Register with combined natural language + structured description
+description := `Creates a new user account with the provided information.
+Parameters: {"name": {"type": "string", "description": "Full name of the user"}, "email": {"type": "string", "description": "Email address"}, "age": {"type": "number", "description": "Age in years", "minimum": 0}}
+The name and email are required. Age is optional and must be non-negative.
+Returns: {"userId": "string", "created": "boolean"}`
+
+agentsdk.DescribeServiceMethodLLM(server, "UserService.CreateUser", description, "User creation result")
+```
+
+**Pros:**
+- More flexible and human-readable descriptions
+- Can include examples, edge cases, and natural language guidance
+- Better suited for AI/LLM understanding
+- Easier to write rich, contextual descriptions
+
+**Cons:**
+- Less strict type validation
+- More suitable for AI agents than traditional programmatic clients
+- Parameter validation relies on description accuracy
+
+#### Choosing Between Approaches
+
+**Use `DescribeServiceMethod` when:**
+- Building APIs for traditional software clients
+- You need strict type validation and contracts
+- Your API has stable, well-defined parameter structures
+- You're integrating with existing systems that expect structured schemas
+
+**Use `DescribeServiceMethodLLM` when:**
+- Building APIs specifically for AI agents or LLMs
+- You want to provide rich contextual information
+- Your API parameters are complex or dynamic
+- You want flexibility in how parameters are described
+- You're building agent-to-agent communication systems
+
+Both approaches produce the same runtime behavior - they just differ in how method information is described and validated.
 
 ### Start your server
 ```go

--- a/examples/llm_description_example/README.md
+++ b/examples/llm_description_example/README.md
@@ -1,0 +1,89 @@
+# LLM Description Example
+
+This example demonstrates how to use LLM-friendly method descriptions with the agent SDK. Instead of providing structured parameter schemas, you can provide natural language descriptions that include parameter information in a way that's easily understandable by Large Language Models.
+
+## What It Demonstrates
+
+### LLM-Friendly Method Registration
+Instead of using structured parameter maps like this:
+
+```go
+parameters := map[string]any{
+    "a": map[string]any{
+        "type":        "integer",
+        "description": "First number to add",
+        "required":    true,
+    },
+    "b": map[string]any{
+        "type":        "integer",
+        "description": "Second number to add",
+        "required":    true,
+    },
+}
+agentsdk.DescribeServiceMethod(server, "MathService", "Add", "Adds two integers", parameters)
+```
+
+You can use a combined natural language + structured description:
+
+```go
+addDescription := `Adds two integers together.
+Parameters: {"a": {"type": "integer", "description": "First number to add"}, "b": {"type": "integer", "description": "Second number to add"}}
+Returns the sum of the two numbers.`
+
+agentsdk.DescribeServiceMethodLLM(server, "MathService.Add", addDescription, "integer")
+```
+
+### Benefits of LLM Descriptions
+
+1. **More Flexible**: You can mix natural language explanations with structured data
+2. **LLM-Optimized**: Designed to be easily parsed and understood by language models
+3. **Human-Readable**: Easier to write and maintain than nested map structures
+4. **Rich Context**: Can include examples, edge cases, and usage notes
+
+## Running the Example
+
+```bash
+go run examples/llm_description_example/main.go
+```
+
+The server will start on port 8080. You can:
+
+### View Tool Descriptions
+```bash
+curl http://localhost:8080/agents/api/v1/tools
+```
+
+This will show the LLM-friendly descriptions for both Add and Multiply methods.
+
+### Execute Methods
+```bash
+# Add two numbers
+curl -X POST http://localhost:8080/agents/api/v1/execute \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "MathService.Add", "params": {"a": 5, "b": 3}, "id": 1}'
+
+# Multiply two numbers
+curl -X POST http://localhost:8080/agents/api/v1/execute \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "MathService.Multiply", "params": {"a": 4, "b": 7}, "id": 1}'
+```
+
+## Key Features
+
+- **Service Registration**: Shows how to register a Go service with methods
+- **LLM Method Descriptions**: Demonstrates the new `DescribeServiceMethodLLM` function
+- **Combined Descriptions**: Shows how natural language and JSON schemas can coexist
+- **Return Type Specification**: Shows how to specify return types for LLM understanding
+
+## When to Use LLM Descriptions
+
+Use `DescribeServiceMethodLLM` when:
+- You want more flexibility in describing method parameters
+- You're building APIs that will be consumed by LLMs or AI agents
+- You want to include rich context, examples, or natural language explanations
+- The structured parameter format feels too restrictive
+
+Use traditional `DescribeServiceMethod` when:
+- You need strict type validation
+- You're building APIs for traditional programmatic clients
+- You prefer the structured parameter schema approach

--- a/examples/llm_description_example/main.go
+++ b/examples/llm_description_example/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	agentsdk "github.com/pangobit/agent-sdk/pkg"
+)
+
+// Simple math service for demonstration
+type MathService struct{}
+
+// AddRequest represents the request for addition
+type AddRequest struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+// AddResponse represents the response for addition
+type AddResponse struct {
+	Result int `json:"result"`
+}
+
+// Add performs addition of two numbers
+func (m *MathService) Add(req AddRequest, resp *AddResponse) error {
+	resp.Result = req.A + req.B
+	return nil
+}
+
+// MultiplyRequest represents the request for multiplication
+type MultiplyRequest struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+// MultiplyResponse represents the response for multiplication
+type MultiplyResponse struct {
+	Result int `json:"result"`
+}
+
+// Multiply performs multiplication of two numbers
+func (m *MathService) Multiply(req MultiplyRequest, resp *MultiplyResponse) error {
+	resp.Result = req.A * req.B
+	return nil
+}
+
+func main() {
+	// Create a new default server
+	server := agentsdk.NewDefaultServer()
+
+	// Register the service
+	if err := agentsdk.RegisterService(server, &MathService{}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Register methods using LLM-friendly descriptions
+	// These descriptions contain both natural language and structured parameter information
+	// that LLMs can understand and use to generate appropriate calls
+
+	addDescription := `Adds two integers together.
+Parameters: {"a": {"type": "integer", "description": "First number to add"}, "b": {"type": "integer", "description": "Second number to add"}}
+Returns the sum of the two numbers.`
+
+	if err := agentsdk.DescribeServiceMethodLLM(server, "MathService.Add", addDescription, "integer"); err != nil {
+		log.Fatal(err)
+	}
+
+	multiplyDescription := `Multiplies two integers together.
+Parameters: {"a": {"type": "integer", "description": "First number to multiply"}, "b": {"type": "integer", "description": "Second number to multiply"}}
+Returns the product of the two numbers.`
+
+	if err := agentsdk.DescribeServiceMethodLLM(server, "MathService.Multiply", multiplyDescription, "integer"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("LLM-Friendly Math Service")
+	fmt.Println("========================")
+	fmt.Println("Server starting on :8080")
+	fmt.Println("Available endpoints:")
+	fmt.Println("  GET  /agents/api/v1/tools   - Tool discovery with LLM descriptions")
+	fmt.Println("  POST /agents/api/v1/execute - Method execution")
+	fmt.Println("")
+	fmt.Println("Example tool discovery:")
+	fmt.Println("  curl http://localhost:8080/agents/api/v1/tools")
+	fmt.Println("")
+	fmt.Println("Example method execution:")
+	fmt.Println("  curl -X POST http://localhost:8080/agents/api/v1/execute \\")
+	fmt.Println("    -H 'Content-Type: application/json' \\")
+	fmt.Println("    -d '{\"jsonrpc\": \"2.0\", \"method\": \"MathService.Add\", \"params\": {\"a\": 5, \"b\": 3}, \"id\": 1}'")
+
+	log.Fatal(server.ListenAndServe(":8080"))
+}

--- a/examples/mixed_registration/README.md
+++ b/examples/mixed_registration/README.md
@@ -1,0 +1,50 @@
+## Mixed Registration Example
+
+This example demonstrates both traditional struct-based method registration and the new LLM-friendly combined description registration approach.
+
+### Features Demonstrated
+
+1. **Traditional Struct-Based Registration**: Uses `DescribeServiceMethod` with structured parameter schemas
+2. **LLM-Friendly Registration**: Uses `DescribeServiceMethodLLM` with combined natural language + schema descriptions
+
+### Running the Example
+
+```bash
+go run main.go
+```
+
+The server will start on port 8080. Visit `http://localhost:8080/agents/api/v1/tools` to see the registered tools.
+
+### Tool Discovery Response
+
+The `/tools` endpoint will return information about both registered methods:
+
+```json
+{
+  "tools": {
+    "CalculatorService.Add": {
+      "name": "CalculatorService.Add",
+      "description": "Adds two integers together",
+      "parameters": {
+        "a": {"type": "integer", "description": "First number to add", "required": true},
+        "b": {"type": "integer", "description": "Second number to add", "required": true}
+      },
+      "returns": ""
+    },
+    "CalculatorService.Multiply": {
+      "name": "CalculatorService.Multiply", 
+      "description": "Multiplies two numbers together.\nParameters: {\"x\": {\"type\": \"number\", \"description\": \"First number\"}, \"y\": {\"type\": \"number\", \"description\": \"Second number\"}}\nReturns: The product of x and y as a number",
+      "parameters": null,
+      "returns": "number"
+    }
+  },
+  "description": "Available tools for LLM-powered applications"
+}
+```
+
+### Key Differences
+
+- **Struct Mode** (`CalculatorService.Add`): Uses structured parameter schemas that are validated against Go struct fields
+- **LLM Mode** (`CalculatorService.Multiply`): Uses a combined description that includes both natural language and parameter schemas, giving implementors full flexibility in how they describe their APIs for LLM consumption
+
+Both modes work with the same JSON-RPC execution endpoint, but LLM mode provides more flexibility for describing complex or dynamic APIs.

--- a/examples/mixed_registration/main.go
+++ b/examples/mixed_registration/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	agentsdk "github.com/pangobit/agent-sdk/pkg"
+)
+
+// CalculatorService provides calculation operations
+type CalculatorService struct{}
+
+// AddRequest represents the request for addition
+type AddRequest struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+// AddResponse represents the response for addition
+type AddResponse struct {
+	Result int `json:"result"`
+}
+
+func (c *CalculatorService) Add(req AddRequest, resp *AddResponse) error {
+	resp.Result = req.A + req.B
+	return nil
+}
+
+func main() {
+	// Create a new default server
+	srv := agentsdk.NewDefaultServer()
+
+	// Register the service
+	if err := agentsdk.RegisterService(srv, &CalculatorService{}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Register method using traditional struct-based approach
+	parameters := map[string]interface{}{
+		"a": map[string]interface{}{
+			"type":        "integer",
+			"description": "First number to add",
+			"required":    true,
+		},
+		"b": map[string]interface{}{
+			"type":        "integer",
+			"description": "Second number to add",
+			"required":    true,
+		},
+	}
+
+	if err := agentsdk.DescribeServiceMethod(srv, "CalculatorService", "Add",
+		"Adds two integers together", parameters); err != nil {
+		log.Fatal(err)
+	}
+
+	// Register method using new LLM-friendly approach
+	llmDescription := `Multiplies two numbers together.
+Parameters: {"x": {"type": "number", "description": "First number"}, "y": {"type": "number", "description": "Second number"}}
+Returns: The product of x and y as a number`
+
+	if err := agentsdk.DescribeServiceMethodLLM(srv, "CalculatorService.Multiply",
+		llmDescription, "number"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Server starting on :8080")
+	fmt.Println("Visit http://localhost:8080/agents/api/v1/tools to see registered tools")
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -94,3 +94,23 @@ func RegisterService(server *server.Server, service any) error {
 func DescribeServiceMethod(server *server.Server, serviceName, methodName, description string, parameters map[string]any) error {
 	return server.RegisterMethod(serviceName, methodName, description, parameters)
 }
+
+// DescribeServiceMethodLLM creates a tool description for a service method using LLM-friendly combined description.
+// This is an alternative to DescribeServiceMethod that allows for more flexible parameter descriptions
+// suitable for LLM consumption.
+//
+// The description parameter should contain all necessary information for an LLM to understand
+// how to call the method, including parameter schemas, examples, and natural language guidance.
+// The optional returns parameter specifies the return type description.
+//
+// The methodName should be in the format "ServiceName.MethodName".
+//
+// Example:
+//
+//	description := `Sends a greeting message to the specified name.
+//	Parameters: {"name": {"type": "string", "description": "The name to greet", "required": true}}
+//	Returns: {"message": "Hello, {name}!", "success": true}`
+//	err := agentsdk.DescribeServiceMethodLLM(server, "HelloService.Hello", description, "Greeting response object")
+func DescribeServiceMethodLLM(server *server.Server, methodName, description string, returns ...string) error {
+	return server.RegisterMethodLLM(methodName, description, returns...)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,8 @@ type Transport interface {
 // ToolRegistry defines the interface for tool registration
 type ToolRegistry interface {
 	RegisterMethod(serviceName, methodName, description string, parameters map[string]interface{}) error
+	// RegisterMethodLLM registers a method using LLM-friendly combined description
+	RegisterMethodLLM(methodName, description string, returns ...string) error
 }
 
 // MethodExecutor defines the interface for executing methods
@@ -86,6 +88,21 @@ func (s *Server) RegisterMethod(serviceName, methodName, description string, par
 		return fmt.Errorf("tool registry not configured")
 	}
 	return s.toolRegistry.RegisterMethod(serviceName, methodName, description, parameters)
+}
+
+// RegisterMethodLLM registers a method using LLM-friendly combined description.
+// This method provides an alternative to RegisterMethod that allows for more flexible
+// parameter descriptions suitable for LLM consumption. The description parameter should
+// contain all necessary information for an LLM to understand how to call the method,
+// including parameter schemas, examples, and natural language guidance.
+//
+// The methodName should be in the format "ServiceName.MethodName".
+// The optional returns parameter specifies the return type description.
+func (s *Server) RegisterMethodLLM(methodName, description string, returns ...string) error {
+	if s.toolRegistry == nil {
+		return fmt.Errorf("tool registry not configured")
+	}
+	return s.toolRegistry.RegisterMethodLLM(methodName, description, returns...)
 }
 
 // ExecuteMethod executes a method through the method executor


### PR DESCRIPTION
Previously, the library assumed you'd pass in some sort of structured parameter map (map[string]any). 
You can now additionally pass in a simple string description. This is useful for cases in which you want to lean more heavily on the LLM calling the agentsdk server /tools endpoint to infer the best way to call the service.